### PR TITLE
Add Docker Hub build hook

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN wget --progress="dot:mega" "https://github.com/Intellection/vault-init/relea
     wget --progress="dot:mega" "https://github.com/Intellection/vault-init/releases/download/${VAULT_INIT_VERSION}/${VAULT_INIT_PACKAGE}-shasum-256.txt" && \
     sha256sum -c "${VAULT_INIT_PACKAGE}-shasum-256.txt" && \
     tar --no-same-owner -xzf "${VAULT_INIT_PACKAGE}.tar.gz" && \
-    mv "/${VAULT_INIT_PACKAGE}" "/usr/local/bin/vault-init" && \
+    mv "${VAULT_INIT_PACKAGE}" "/usr/local/bin/vault-init" && \
     chmod +x "/usr/local/bin/vault-init" && \
     rm -f ${VAULT_INIT_PACKAGE}*
 

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "Running build hook"
+docker build --build-arg VAULT_INIT_VERSION="${SOURCE_BRANCH}" -t "${IMAGE_NAME}" .


### PR DESCRIPTION
What it says on the tin.

We need this custom phase hook to inject the tag (contained in the environment variable `SOURCE_BRANCH `) into the `docker build` command.

See related documentation:
https://docs.docker.com/docker-hub/builds/advanced/#custom-build-phase-hooks