### PR TITLE
Retry init until Vault can provide a response.

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -266,6 +266,6 @@ func handleSig() {
 	<-sigChannel
 	fmt.Println()
 	fmt.Println("Shutting down...")
-	os.Exit(0)
 	exit <- true
+	os.Exit(0)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -77,13 +77,7 @@ need to read from or write to the Vault instance.`,
 			vaultAddr = "http://127.0.0.1:8200"
 		}
 
-		httpClient = http.Client{
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{
-					InsecureSkipVerify: false,
-				},
-			},
-		}
+		httpClient = http.Client{}
 		healthCode := healthCheck(vaultAddr)
 		switch healthCode {
 		case 200:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -105,6 +105,7 @@ need to read from or write to the Vault instance.`,
 		default:
 			log.Printf("Vault is in an unknown state. Health status code: %d. Going dormant...", healthCode)
 		}
+
 		if intitialise {
 			// make vault init request and get root token
 			fmt.Println("Initialising Vault...")
@@ -147,6 +148,7 @@ need to read from or write to the Vault instance.`,
 			checkError(errS3)
 			fmt.Println("Encrypted token successfully uploaded to S3 at", s3Result.Location)
 		}
+
 		<-exit
 	},
 }


### PR DESCRIPTION
## Handling Vault as a dependency
Allow Vault Init to wait for Vault to start up. Once vault has start, Vault Init will check the state of vault via the health endpoint and log the state to stdout based on [the state related error codes received](https://www.vaultproject.io/api/system/health.html).

Initialisation will only be run for 501 status. See the above mentioned docs for the meaning of this status.

## Signal handling and remaining alive to maintain pod health
Vault Init will exit waiting on receiving `SIGINT`, `SIGKILL`, or `SIGTERM`.

After initialising Vault Init will remain alive blocking until one of the above mentioned signals are received. This blocking behaviour is require to keep the container alive so Kubernetes will consider the pod containing it to be healthy. To this end the blocking also applies to other states where initialisation does not occur.